### PR TITLE
Schema validation is not possible when using the new implementation

### DIFF
--- a/content/refguide/call-web-service-action.md
+++ b/content/refguide/call-web-service-action.md
@@ -57,7 +57,17 @@ Setting this setting to yes can greatly decrease performance!
 
 {{% alert type="warning" %}}
 
-When consuming wsdl that uses encoding turning on validation will lead to consistency error because it is not WS-I compliant.
+When consuming a wsdl that uses encoding, turning on validation will lead to a consistency error because it is not WS-I compliant.
+
+{{% /alert %}}
+
+When this setting is disabled, schema validation is not possible. This happens in two cases:
+ - When you have configured the [consumed web service](consumed-web-service) to send binary data as attachments
+ - When you have configured web service calls to use the new (optimized) implementation in the [project's runtime settings](project-settings)
+
+{{% alert type="info" %}}
+
+The new (optimized) implementation feature was introduced in version 7.15.0.
 
 {{% /alert %}}
 


### PR DESCRIPTION
Schema validation is not possible when using the new implementation for web service calls