### PR TITLE
Renamed 'Mendix Runtime API' to 'Runtime API'

### DIFF
--- a/content/en/docs/apidocs-mxsdk/apidocs/runtime-api.md
+++ b/content/en/docs/apidocs-mxsdk/apidocs/runtime-api.md
@@ -1,5 +1,5 @@
 ---
-title: "Mendix Runtime API"
+title: "Runtime API"
 url: /apidocs-mxsdk/apidocs/runtime-api/
 category: "API Documentation"
 description: "All the functionality and information from both the application model and Mendix Runtime is accessible via this API."


### PR DESCRIPTION
The prefix made it difficult to find in an alphabetical list of pages on https://docs.mendix.com/apidocs-mxsdk/apidocs/, because the other pages do not have the Mendix prefix.